### PR TITLE
Support random examples

### DIFF
--- a/scripts/run_langchain.py
+++ b/scripts/run_langchain.py
@@ -17,6 +17,7 @@ from rich import print
 from rich.progress import track
 from sentence_transformers import util
 
+
 # The maximum number of tokens in the input and output
 MAX_INPUT_TOKENS = 6192
 MAX_OUTPUT_TOKENS = 2000


### PR DESCRIPTION
This PR supports the use of random in-context examples with the `run_langchain.py` script. A user just needs to provide `--strategy 'random'`. The default strategy will be the previous strategy of selection examples based on dialogue similarity.